### PR TITLE
Provide support for a default language

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -23,6 +23,7 @@
     options = options || {};
     this.phrases = options.phrases || {};
     this.currentLocale = options.locale || 'en';
+    this.allowMissing = !!options.allowMissing;
   }
 
   // ### Version
@@ -104,7 +105,7 @@
   Polyglot.prototype.t = function(key, options) {
     var result;
     options = options || {};
-    var phrase = this.phrases[key] || options._ || key;
+    var phrase = this.phrases[key] || options._ || (this.allowMissing ? key : '');
     if (phrase === '') {
       warn('Missing translation for key: "'+key+'"');
       result = key;

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -29,6 +29,17 @@ describe "t", ->
       name: "Robert"
     ).should.equal "Can I call you Robert?"
 
+  it "should return the non-interpolated key if not initialized with allowMissing and translation not found", ->
+    @polyglot.t("Welcome %{name}",
+      name: "Robert"
+    ).should.equal "Welcome %{name}"
+
+  it "should return an interpolated key if initialized with allowMissing and translation not found", ->
+    @polyglot = new Polyglot({phrases:phrases,allowMissing:true})
+    @polyglot.t("Welcome %{name}",
+      name: "Robert"
+    ).should.equal "Welcome Robert"
+
 describe "locale", ->
 
   beforeEach ->


### PR DESCRIPTION
For the use case where most of the users of a given application have the same language, allow polyglot to fall back on using the key as the actual translation.

The current code does return the key, but in case the key contains an interpolation or a plural it will not be taken into account.

This change not only removes the necessity for having a JSON for your most popular language, but also makes it easier to translate your app to other languages:
1. Write your HTML templates using, e.g.:

```
{{polyglot.t('Welcome %{name}', {name: name})}}
```
1. If your user's preferred language is English, initialize an empty `new Polyglot()`, and everything works as expected
2. Parse your templates for calls to `polyglot.t` and generate an empty JSON for the new language you are ready to translate
3. The phrases to translate are more explicit because the keys in your JSON correspond to the actual English phrase
