### PR TITLE
Adding additional plural rule members for three languages

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -185,9 +185,9 @@
 
   // Mapping from pluralization group to individual locales.
   var pluralTypeToLanguages = {
-    chinese:   ['id', 'ja', 'ko', 'ms', 'th', 'tr', 'zh'],
+    chinese:   ['fa', 'id', 'ja', 'ko', 'lo', 'ms', 'th', 'tr', 'zh'],
     german:    ['da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hu', 'it', 'nl', 'no', 'pt', 'sv'],
-    french:    ['fr', 'tl'],
+    french:    ['fr', 'tl', 'pt-br'],
     russian:   ['hr', 'ru'],
     czech:     ['cs'],
     polish:    ['pl'],
@@ -280,4 +280,3 @@
   }
 
 }(this);
-


### PR DESCRIPTION
Adding support for Brazilian Portuguese (french / 2 plural rule), Persian (chinese / 0 plural rule), and Lao (chinese / 0 plural rule).
