### PR TITLE
Allow overriding the warn handler.

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -25,6 +25,7 @@
     this.extend(options.phrases || {});
     this.currentLocale = options.locale || 'en';
     this.allowMissing = !!options.allowMissing;
+    this.warn = options.warn || warn;
   }
 
   // ### Version
@@ -157,7 +158,7 @@
     }
     var phrase = this.phrases[key] || options._ || (this.allowMissing ? key : '');
     if (phrase === '') {
-      warn('Missing translation for key: "'+key+'"');
+      this.warn('Missing translation for key: "'+key+'"');
       result = key;
     } else {
       options = clone(options);


### PR DESCRIPTION
We'd like to pull errors during translation into our error pipeline, so we can be notified if anything falls back to the key.
