### PR TITLE
Add has method

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -169,6 +169,14 @@
   };
 
 
+  // ### polyglot.has(key)
+  //
+  // Check if polyglot has a translation for given key
+  Polyglot.prototype.has = function(key) {
+    return key in this.phrases;
+  };
+
+
   // #### Pluralization methods
   // The string that separates the different phrase possibilities.
   var delimeter = '||||';


### PR DESCRIPTION
I'm often need to check if I have a translation for a given key. *(e.g. I provide default labels for backbone forms to make my views more DRY)*

I know that I can just check `key in polyglot.phrases` myself, but I think that `has` method would be a nice syntactic sugar around that common procedure.

I'm aware of `allowMissing` option, but it won't cut it here, because I don't want to see key values.
As an option, instead of adding that method, I could add another options like `emptyMissing` to return `false` or empty string when there's no translation.

Would do you think? 