### PR TITLE
Add Slovak language to the Czech pluralization group

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -190,7 +190,7 @@
     german:    ['da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hu', 'it', 'nl', 'no', 'pt', 'sv'],
     french:    ['fr', 'tl', 'pt-br'],
     russian:   ['hr', 'ru'],
-    czech:     ['cs'],
+    czech:     ['cs', 'sk'],
     polish:    ['pl'],
     icelandic: ['is']
   };


### PR DESCRIPTION
Based on [Mozilla localization docs](https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_and_Plurals).