### PR TITLE
Handle no window object with Webpack

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -283,7 +283,7 @@
   //
   // Provides a warning in the console if a phrase key is missing.
   function warn(message) {
-    root.console && root.console.warn && root.console.warn('WARNING: ' + message);
+    root && root.console && root.console.warn && root.console.warn('WARNING: ' + message);
   }
 
   // ### clone

--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -26,7 +26,14 @@
   } else {
     root.Polyglot = factory(root);
   }
-}(this || global, function(root) {
+}(
+  (function () {
+    if (typeof self !== 'undefined') return self;
+    if (typeof window !== 'undefined') return window;
+    if (typeof global !== 'undefined') return global;
+    return this;  
+  })()
+  , function(root) {
   'use strict';
 
   // ### Polyglot class constructor

--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -26,7 +26,7 @@
   } else {
     root.Polyglot = factory(root);
   }
-}(this, function(root) {
+}(this || global, function(root) {
   'use strict';
 
   // ### Polyglot class constructor
@@ -283,7 +283,7 @@
   //
   // Provides a warning in the console if a phrase key is missing.
   function warn(message) {
-    root && root.console && root.console.warn && root.console.warn('WARNING: ' + message);
+    root.console && root.console.warn && root.console.warn('WARNING: ' + message);
   }
 
   // ### clone


### PR DESCRIPTION
In environments like Webpack there is no `this` to refer to the global object. But you do have global, which is the Node global object.

I suggest supporting that to ensure logging works. An other fix would be to check if `root` actually exists when logging.

At least now it breaks with Webpack, which is too bad :-/