### PR TITLE
Added 'unset' prototype method

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -115,6 +115,37 @@
     }
   };
 
+  // ### polyglot.unset(phrases)
+  // Use `unset` to selectively remove keys from a polyglot instance.
+  //
+  //     polyglot.unset("some_key");
+  //     polyglot.unset({
+  //       "hello": "Hello",
+  //       "hello_name": "Hello, %{name}"
+  //     });
+  //
+  // The unset method can take either a string (for the key), or an object hash with
+  // the keys that you would like to unset.
+  Polyglot.prototype.unset = function(morePhrases, prefix) {
+    var phrase;
+
+    if (typeof morePhrases === 'string') {
+      delete this.phrases[morePhrases];
+    } else {
+      for (var key in morePhrases) {
+        if (morePhrases.hasOwnProperty(key)) {
+          phrase = morePhrases[key];
+          if (prefix) key = prefix + '.' + key;
+          if (typeof phrase === 'object') {
+            this.unset(phrase, key);
+          } else {
+            delete this.phrases[key];
+          }
+        }
+      }
+    }
+  };
+
   // ### polyglot.clear()
   //
   // Clears all phrases. Useful for special cases, such as freeing

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -157,3 +157,25 @@ describe "replace", ->
     @polyglot.replace {hiFriend: "Hi, Friend."}
     @polyglot.t("hiFriend").should.equal "Hi, Friend."
     @polyglot.t("byeFriend").should.equal "byeFriend"
+
+describe "unset", ->
+
+  it "should unset a key based on a string", ->
+    @polyglot.extend { test_key: "test_value"}
+    @polyglot.has("test_key").should.equal true
+    @polyglot.unset("test_key")
+    @polyglot.has("test_key").should.equal false
+
+  it "should unset a key based on an object hash", ->
+    @polyglot.extend { test_key: "test_value", foo: "bar" }
+    @polyglot.has("test_key").should.equal true
+    @polyglot.has("foo").should.equal true
+    @polyglot.unset { test_key: "test_value", foo: "bar" }
+    @polyglot.has("test_key").should.equal false
+    @polyglot.has("foo").should.equal false
+
+  it "should unset nested objects using recursive prefix call", ->
+    @polyglot.extend { foo: { bar: "foobar" }}
+    @polyglot.has("foo.bar").should.equal true
+    @polyglot.unset { foo: { bar: "foobar" }}
+    @polyglot.has("foo.bar").should.equal false


### PR DESCRIPTION
to: @spikebrehm 
cc: @ljharb 

This PR adds an "unset" method to the polyglot prototype. This function allows one to selectively "unset" certain keys on a polyglot instance.

To be honest, this method is mainly useful (or at least is only useful to us right now) as a method to facilitate testing.