### PR TITLE
Don't test Travis for Node <= 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-  - "0.9"
-  - "0.8"
-  - "0.6"
-  - "0.4"
 before_install:
   - '[ "${TRAVIS_NODE_VERSION}" = "0.6" ] || npm install -g npm@1.4.28 && npm install -g npm'
 sudo: false
@@ -52,7 +48,3 @@ matrix:
     - node_js: "iojs-v1.1"
     - node_js: "iojs-v1.0"
     - node_js: "0.11"
-    - node_js: "0.9"
-    - node_js: "0.8"
-    - node_js: "0.6"
-    - node_js: "0.4"


### PR DESCRIPTION
Because those Nodes are old and unsupported.

In #41 they stopped building, and it's not worth investigating why.

to: @ljharb @lelandrichardson 