### PR TITLE
Use a SPDX-compliant license string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "should": "1.2.1",
     "coffee-script": "1.3.3"
   },
-  "license": "BSD"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
@spikebrehm i'm assuming the original "bsd" intention was the 2-clause form?