### PR TITLE
Fix `warn` messages in `node`, where `this` is not the global object

### DIFF
--- a/lib/polyglot.js
+++ b/lib/polyglot.js
@@ -26,7 +26,7 @@
   } else {
     root.Polyglot = factory(root);
   }
-}(this, function(root) {
+}(typeof global !== 'undefined' ? global : this, function(root) {
   'use strict';
 
   var replace = String.prototype.replace;


### PR DESCRIPTION
`this` in a node module isn't the global object - which means this was suppressing warning messages both in tests, and whenever polyglot was being used in node.