### PR TITLE
Add option to modify the tokenPattern used to replace the interpolations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ polyglot.t("nav.sidebar.welcome");
 => "Welcome"
 ```
 
+The substitution variable syntax is customizable.
+
+```js
+var polyglot = new Polyglot({
+  phrases: {
+    "hello_name": "Hola {{name}}"
+  },
+  interpolation: {prefix: '{{', suffix: '}}'}
+});
+
+polyglot.t("hello_name", {name: "DeNiro"});
+=> "Hola, DeNiro."
+```
+
 ### Pluralization
 
 For pluralization to work properly, you need to tell Polyglot what the current locale is. You can use `polyglot.locale("fr")` to set the locale to, for example, French. This method is also a getter:
@@ -284,6 +298,7 @@ You should pass in a third argument, the locale, to specify the correct plural t
  - `locale`: a string describing the locale (language and region) of the translation, to apply pluralization rules. see [Pluralization](#pluralization)
  - `allowMissing`: a boolean to control whether missing keys in a `t` call are allowed. If `false`, by default, a missing key is returned and a warning is issued.
  - `onMissingKey`: if `allowMissing` is `true`, and this option is a function, then it will be called instead of the default functionality. Arguments passed to it are `key`, `options`, and `locale`. The return of this function will be used as a translation fallback when `polyglot.t('missing.key')` is called (hint: return the key).
+ - `interpolation`: an object to change the substitution syntax for interpolation by setting the `prefix` and `suffix` fields.
 
 
 ## [History](CHANGELOG.md)

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,38 @@ describe('t', function () {
     })).to.equal('Welcome Robert');
   });
 
+  describe('custom interpolation syntax', function () {
+    var createWithInterpolation = function (interpolation) {
+      return new Polyglot({ phrases: {}, allowMissing: true, interpolation: interpolation });
+    };
+
+    it('interpolates with the specified custom token syntax', function () {
+      var instance = createWithInterpolation({ prefix: '{{', suffix: '}}' });
+      expect(instance.t('Welcome {{name}}', {
+        name: 'Robert'
+      })).to.equal('Welcome Robert');
+    });
+
+    it('interpolates if the prefix and suffix are the same', function () {
+      var instance = createWithInterpolation({ prefix: '|', suffix: '|' });
+      expect(instance.t('Welcome |name|, how are you, |name|?', {
+        name: 'Robert'
+      })).to.equal('Welcome Robert, how are you, Robert?');
+    });
+
+    it('interpolates when using regular expression tokens', function () {
+      var instance = createWithInterpolation({ prefix: '\\s.*', suffix: '\\d.+' });
+      expect(instance.t('Welcome \\s.*name\\d.+', {
+        name: 'Robert'
+      })).to.equal('Welcome Robert');
+    });
+
+    it('throws an error when either prefix or suffix equals to pluralization delimiter', function () {
+      expect(function () { createWithInterpolation({ prefix: '||||', suffix: '}}' }); }).to.throw(RangeError);
+      expect(function () { createWithInterpolation({ prefix: '{{', suffix: '||||' }); }).to.throw(RangeError);
+    });
+  });
+
   it('returns the translation even if it is an empty string', function () {
     expect(polyglot.t('empty_string')).to.equal('');
   });


### PR DESCRIPTION
I needed to change the tokenPattern because I already have the phrases made with other pattern, used in the server-side. 
So this PR adds the possibility of change that in the settings, just passing a parameter `tokenPattern` in the Polyglot options object. 

``` js

new Polyglot({
    phrases: {
        "hello_name": "Hola, {{name}}."
    },
    tokenPattern: '{{(.*?)}}'
});
```

I hope this gets merged with the main branch and published in NPM soon, so I can use it as a module in my project :) 

Thanks! 
Luciano
