### PR TITLE
[New] add `onMissingKey` constructor option

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,8 @@ function Polyglot(options) {
   this.phrases = {};
   this.extend(opts.phrases || {});
   this.currentLocale = opts.locale || 'en';
-  this.allowMissing = !!opts.allowMissing;
+  var allowMissing = opts.allowMissing ? transformPhrase : null;
+  this.onMissingKey = typeof opts.onMissingKey === 'function' ? opts.onMissingKey : allowMissing;
   this.warn = opts.warn || warn;
 }
 
@@ -307,8 +308,9 @@ Polyglot.prototype.t = function (key, options) {
     phrase = this.phrases[key];
   } else if (typeof opts._ === 'string') {
     phrase = opts._;
-  } else if (this.allowMissing) {
-    phrase = key;
+  } else if (this.onMissingKey) {
+    var onMissingKey = this.onMissingKey;
+    result = onMissingKey(key, opts, this.currentLocale);
   } else {
     this.warn('Missing translation for key: "' + key + '"');
     result = key;

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,34 @@ describe('t', function () {
     expect(instance.t('nav.cta.join_now')).to.equal('Join now!');
     expect(instance.t('header.sign_in')).to.equal('Sign In');
   });
+
+  describe('onMissingKey', function () {
+    it('calls the function when a key is missing', function () {
+      var expectedKey = 'some key';
+      var expectedOptions = {};
+      var expectedLocale = 'oz';
+      var returnValue = {};
+      var onMissingKey = function (key, options, locale) {
+        expect(key).to.equal(expectedKey);
+        expect(options).to.equal(expectedOptions);
+        expect(locale).to.equal(expectedLocale);
+        return returnValue;
+      };
+      var instance = new Polyglot({ onMissingKey: onMissingKey, locale: expectedLocale });
+      var result = instance.t(expectedKey, expectedOptions);
+      expect(result).to.equal(returnValue);
+    });
+
+    it('overrides allowMissing', function (done) {
+      var missingKey = 'missing key';
+      var onMissingKey = function (key) {
+        expect(key).to.equal(missingKey);
+        done();
+      };
+      var instance = new Polyglot({ onMissingKey: onMissingKey, allowMissing: true });
+      instance.t(missingKey);
+    });
+  });
 });
 
 describe('pluralize', function () {


### PR DESCRIPTION
This can call `.transformPhrase`, or return `false`, or `undefined`, or throw - whatever you like.

`onMissingKey` overrides `allowMissing`, which is now deprecated.

Fixes #34.