### PR TITLE
Remove warning when translating the empty key

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,6 +302,9 @@ Polyglot.prototype.replace = function (newPhrases) {
 //     => "I like to write in JavaScript."
 //
 Polyglot.prototype.t = function (key, options) {
+  if (!key) {
+    return '';
+  }
   var phrase, result;
   var opts = options == null ? {} : options;
   if (typeof this.phrases[key] === 'string') {

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,14 @@ describe('t', function () {
     expect(polyglot.t('bogus_key')).to.equal('bogus_key');
   });
 
+  it('does not warn for empty string', function () {
+    var onMissingKey = function () {
+      expect(true).to.equal(false);
+    };
+    var instance = new Polyglot({ onMissingKey: onMissingKey });
+    instance.t('');
+  });
+
   it('interpolates', function () {
     expect(polyglot.t('hi_name_welcome_to_place', {
       name: 'Spike',


### PR DESCRIPTION
Some of the strings I translate can sometimes be disabled. Think for instance an Edit button, where the translation key is "edit", but that the developer can override to "" to hide the label.

When that happens, Polyglot warns in the console:

> Warning: Missing translation for key: ""

I think this edge case should be handled by the library.