### PR TITLE
fix spelling of "delimiter" in code & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Polyglot provides a very basic pattern for providing
 pluralization based on a single string that contains all plural forms for a given phrase. Because various languages have different nominal forms for zero, one, and multiple, and because the noun can be before or after the count, we have to be overly explicit
 about the possible phrases.
 
-To get a pluralized phrase, still use `polyglot.t()` but use a specially-formatted phrase string that separates the plural forms by the delimeter `||||`, or four vertical pipe characters.
+To get a pluralized phrase, still use `polyglot.t()` but use a specially-formatted phrase string that separates the plural forms by the delimiter `||||`, or four vertical pipe characters.
 
 For pluralizing "car" in English, Polyglot assumes you have a phrase of the form:
 

--- a/docs/polyglot.html
+++ b/docs/polyglot.html
@@ -71,7 +71,7 @@ your client- or server-side JavaScript application.</p>
 
             </div>
 
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">var</span> delimeter = <span class="hljs-string">'||||'</span>;</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">var</span> delimiter = <span class="hljs-string">'||||'</span>;</pre></div></div>
 
         </li>
 
@@ -239,13 +239,13 @@ It defaults to <code>&#39;en&#39;</code> with 2 plural forms.</p>
                 <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <p>Select plural form: based on a phrase text that contains <code>n</code>
-plural forms separated by <code>delimeter</code>, a <code>locale</code>, and a <code>substitutions.smart_count</code>,
+plural forms separated by <code>delimiter</code>, a <code>locale</code>, and a <code>substitutions.smart_count</code>,
 choose the correct plural form. This is only done if <code>count</code> is set.</p>
 
             </div>
 
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (options.smart_count != <span class="hljs-literal">null</span> &amp;&amp; result) {
-    <span class="hljs-keyword">var</span> texts = split.call(result, delimeter);
+    <span class="hljs-keyword">var</span> texts = split.call(result, delimiter);
     result = trim(texts[pluralTypeIndex(locale || <span class="hljs-string">'en'</span>, options.smart_count)] || texts[<span class="hljs-number">0</span>]);
   }</pre></div></div>
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var split = String.prototype.split;
 
 // #### Pluralization methods
 // The string that separates the different phrase possibilities.
-var delimeter = '||||';
+var delimiter = '||||';
 
 // Mapping from pluralization group plural logic.
 var pluralTypes = {
@@ -134,10 +134,10 @@ function transformPhrase(phrase, substitutions, locale) {
   var options = typeof substitutions === 'number' ? { smart_count: substitutions } : substitutions;
 
   // Select plural form: based on a phrase text that contains `n`
-  // plural forms separated by `delimeter`, a `locale`, and a `substitutions.smart_count`,
+  // plural forms separated by `delimiter`, a `locale`, and a `substitutions.smart_count`,
   // choose the correct plural form. This is only done if `count` is set.
   if (options.smart_count != null && result) {
-    var texts = split.call(result, delimeter);
+    var texts = split.call(result, delimiter);
     result = trim(texts[pluralTypeIndex(locale || 'en', options.smart_count)] || texts[0]);
   }
 


### PR DESCRIPTION
Thanks for this library :)

`npm test` passes.