### PR TITLE
Added be, bs, sh, sr, uk languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,12 +94,12 @@ var pluralTypes = {
 // for language code, and if that does not exist will default to 'en'
 var pluralTypeToLanguages = {
   arabic: ['ar'],
-  bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
+  bosnian_serbian: ['bs', 'bs-Latn-BA', 'bs-Cyrl-BA', 'sr', 'srl-RS', 'sr-RS'],
   chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
   croatian: ['hr', 'hr-HR'],
   german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],
   french: ['fr', 'tl', 'pt-br'],
-  russian: ['ru', 'ru-RU'],
+  russian: ['ru', 'ru-RU', 'be', 'sh', 'uk'],
   lithuanian: ['lt'],
   czech: ['cs', 'cs-CZ', 'sk'],
   polish: ['pl'],

--- a/test/index.js
+++ b/test/index.js
@@ -462,6 +462,7 @@ describe('locale-specific pluralization rules', function () {
     var phrases = {
       n_votes: whatSomeoneTranslated.join(' |||| ')
     };
+
     var polyglot = new Polyglot({ phrases: phrases, locale: 'lt' });
 
     expect(polyglot.t('n_votes', 0)).to.equal('0 balsų');
@@ -475,6 +476,132 @@ describe('locale-specific pluralization rules', function () {
     expect(polyglot.t('n_votes', 91)).to.equal('91 balsas');
     expect(polyglot.t('n_votes', 92)).to.equal('92 balsai');
     expect(polyglot.t('n_votes', 102)).to.equal('102 balsai');
+  });
+
+  it('pluralizes in Belarusian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} голас',
+      '%{smart_count} галасы',
+      '%{smart_count} галасоў'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'be' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 галасоў');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 голас');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 галасы');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 галасоў');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 галасоў');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 галасоў');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 галасы');
+  });
+
+  it('pluralizes in Bosnian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} miš',
+      '%{smart_count} miša',
+      '%{smart_count} miševa'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'bs' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 miševa');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 miš');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 miša');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 miševa');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 miševa');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 miševa');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 miša');
+  });
+
+  it('pluralizes in Russian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} голос',
+      '%{smart_count} голоса',
+      '%{smart_count} голосов'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'ru' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 голосов');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 голос');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 голоса');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 голосов');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 голосов');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 голосов');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 голоса');
+  });
+
+  it('pluralizes in Serbian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} миш',
+      '%{smart_count} миша',
+      '%{smart_count} мишева'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'sr' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 мишева');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 миш');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 миша');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 мишева');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 мишева');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 мишева');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 миша');
+  });
+
+  it('pluralizes in Serbo-Croatian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} miš',
+      '%{smart_count} miša',
+      '%{smart_count} miševa'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'sh' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 miševa');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 miš');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 miša');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 miševa');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 miševa');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 miševa');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 miša');
+  });
+
+  it('pluralizes in Ukranian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} голос',
+      '%{smart_count} голоси',
+      '%{smart_count} голосiв'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'uk' });
+
+    expect(polyglot.t('n_votes', 0)).to.equal('0 голосiв');
+    expect(polyglot.t('n_votes', 1)).to.equal('1 голос');
+    expect(polyglot.t('n_votes', 2)).to.equal('2 голоси');
+    expect(polyglot.t('n_votes', 9)).to.equal('9 голосiв');
+    expect(polyglot.t('n_votes', 10)).to.equal('10 голосiв');
+    expect(polyglot.t('n_votes', 11)).to.equal('11 голосiв');
+    expect(polyglot.t('n_votes', 102)).to.equal('102 голоси');
   });
 });
 


### PR DESCRIPTION
According to
http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#lv-comp,
Belarussian and Ukrainian languages have the same plural form rules,
so it makes sense to add them to the russian plural forms group.

Tests for be, ru, uk languages plural forms added to document this behavior.

Closes #94.