### PR TITLE
Moved tr from chinese to german group

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,9 +100,9 @@ var pluralTypes = {
 var pluralTypeToLanguages = {
   arabic: ['ar'],
   bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
-  chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'tr', 'zh'],
+  chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
   croatian: ['hr', 'hr-HR'],
-  german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv'],
+  german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],
   french: ['fr', 'tl', 'pt-br'],
   russian: ['ru', 'ru-RU', 'lt'],
   czech: ['cs', 'cs-CZ', 'sk'],

--- a/test/index.js
+++ b/test/index.js
@@ -437,6 +437,21 @@ describe('locale-specific pluralization rules', function () {
       expect(polyglot.t('n_votes', c)).to.equal(c + ' komentarjev');
     });
   });
+
+  it('pluralizes in Turkish', function () {
+    var whatSomeoneTranslated = [
+      'Sepetinizde %{smart_count} X var. Bunu almak istiyor musunuz?',
+      'Sepetinizde %{smart_count} X var. Bunları almak istiyor musunuz?'
+    ];
+    var phrases = {
+      n_x_cart: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'tr' });
+
+    expect(polyglot.t('n_x_cart', 1)).to.equal('Sepetinizde 1 X var. Bunu almak istiyor musunuz?');
+    expect(polyglot.t('n_x_cart', 2)).to.equal('Sepetinizde 2 X var. Bunları almak istiyor musunuz?');
+  });
 });
 
 describe('locale', function () {


### PR DESCRIPTION
For Turkish, in the most of the cases number will remain in a singular form, but if a translation string will be used for, per example, 2 sentences, then there's no chance to set the right form for the 2nd sentence, good example is here http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#tr

As putting tr in a correct group wouldn't affect any existing translation tags (as they're singular anyway), I'd suggest keeping the third commit.