### PR TITLE
Fix Russian Logic & added LocalId for russian

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,6 @@
     "one-var-declaration-per-line": 0,
     "no-use-before-define": 1,
     "vars-on-top": 0,
+    "yoda": 1,
   }
 }

--- a/index.js
+++ b/index.js
@@ -45,8 +45,14 @@ var pluralTypes = {
   german: function (n) { return n !== 1 ? 1 : 0; },
   french: function (n) { return n > 1 ? 1 : 0; },
   russian: function (n) {
-    if (n % 10 === 1 && n % 100 !== 11) { return 0; }
-    return n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2;
+    var end = n % 10;
+    if (n !== 11 && end === 1) {
+      return 0;
+    }
+    if (2 <= end && end <= 4 && !(12 <= n && n <= 14)) {
+      return 1;
+    }
+    return 2;
   },
   czech: function (n) {
     if (n === 1) { return 0; }

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ var pluralTypeToLanguages = {
   chinese: ['id', 'ja', 'ko', 'lo', 'ms', 'th', 'tr', 'zh'],
   german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hu', 'it', 'nl', 'no', 'pt', 'sv'],
   french: ['fr', 'tl', 'pt-br'],
-  russian: ['hr', 'ru', 'lt'],
+  russian: ['hr', 'ru', 'ru-RU', 'lt'],
   czech: ['cs', 'sk'],
   polish: ['pl'],
   icelandic: ['is']

--- a/test/index.js
+++ b/test/index.js
@@ -180,6 +180,42 @@ describe('locale-specific pluralization rules', function () {
     expect(polyglot.t('n_votes', 11)).to.equal('11 صوت');
     expect(polyglot.t('n_votes', 102)).to.equal('102 صوت');
   });
+
+  it('pluralizes in Russian', function () {
+    // English would be: "1 vote" / "%{smart_count} votes"
+    var whatSomeoneTranslated = [
+      '%{smart_count} машина',
+      '%{smart_count} машины',
+      '%{smart_count} машин'
+    ];
+    var phrases = {
+      n_votes: whatSomeoneTranslated.join(' |||| ')
+    };
+
+    var polyglotLanguageCode = new Polyglot({ phrases: phrases, locale: 'ru' });
+
+    expect(polyglotLanguageCode.t('n_votes', 1)).to.equal('1 машина');
+    expect(polyglotLanguageCode.t('n_votes', 11)).to.equal('11 машин');
+    expect(polyglotLanguageCode.t('n_votes', 101)).to.equal('101 машина');
+    expect(polyglotLanguageCode.t('n_votes', 932)).to.equal('932 машины');
+    expect(polyglotLanguageCode.t('n_votes', 324)).to.equal('324 машины');
+    expect(polyglotLanguageCode.t('n_votes', 12)).to.equal('12 машин');
+    expect(polyglotLanguageCode.t('n_votes', 13)).to.equal('13 машин');
+    expect(polyglotLanguageCode.t('n_votes', 14)).to.equal('14 машин');
+    expect(polyglotLanguageCode.t('n_votes', 15)).to.equal('15 машин');
+
+    var polyglotLocaleId = new Polyglot({ phrases: phrases, locale: 'ru-RU' });
+
+    expect(polyglotLocaleId.t('n_votes', 1)).to.equal('1 машина');
+    expect(polyglotLocaleId.t('n_votes', 11)).to.equal('11 машин');
+    expect(polyglotLocaleId.t('n_votes', 101)).to.equal('101 машина');
+    expect(polyglotLocaleId.t('n_votes', 932)).to.equal('932 машины');
+    expect(polyglotLocaleId.t('n_votes', 324)).to.equal('324 машины');
+    expect(polyglotLocaleId.t('n_votes', 12)).to.equal('12 машин');
+    expect(polyglotLocaleId.t('n_votes', 13)).to.equal('13 машин');
+    expect(polyglotLocaleId.t('n_votes', 14)).to.equal('14 машин');
+    expect(polyglotLocaleId.t('n_votes', 15)).to.equal('15 машин');
+  });
 });
 
 describe('locale', function () {


### PR DESCRIPTION
After talking to our translator, found a bug in the russian logic.

![image](https://user-images.githubusercontent.com/16171726/41793142-0a4d358a-7610-11e8-8b21-88ba104dce5f.png)

It's related to https://github.com/airbnb/polyglot.js/pull/113 since Serbian and Bosnian actually share the same form as Russian.  Depending how you want to merge the PR, that one can just end up being adding the additional test and new language/localeId.

I created a separate PR just for the Russian fix. 

