### PR TITLE
[Docs] fix typo in the Czech example

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Some languages get a bit more complicated. In Czech, there are three separate fo
 ```js
 var polyglot = new Polyglot({locale: "cs"}); // Czech
 polyglot.extend({
-  "num_foxes": "Mám %{smart_count} liška |||| Mám %{smart_count} lišky |||| Mám %{smart_count} lišek"
+  "num_foxes": "Mám %{smart_count} lišku |||| Mám %{smart_count} lišky |||| Mám %{smart_count} lišek"
 })
 ```
 


### PR DESCRIPTION
There is a typo in the Czech countables example. Currently, the "fox" in the phrase "I have one fox" is in nominative case (liška), however Czech uses accusative case when counting one item (lišku).