### PR TITLE
Feature: add support for picking a random value from an array of phrases

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ Polyglot.prototype.locale = function (newLocale) {
 Polyglot.prototype.extend = function (morePhrases, prefix) {
   forEach(morePhrases, function (phrase, key) {
     var prefixedKey = prefix ? prefix + '.' + key : key;
-    if (typeof phrase === 'object') {
+    if (typeof phrase === 'object' && !Array.isArray(phrase)) {
       this.extend(phrase, prefixedKey);
     } else {
       this.phrases[prefixedKey] = phrase;
@@ -360,6 +360,9 @@ Polyglot.prototype.t = function (key, options) {
   var opts = options == null ? {} : options;
   if (typeof this.phrases[key] === 'string') {
     phrase = this.phrases[key];
+  } else if (Array.isArray(this.phrases[key])) {
+    var random = Math.floor(Math.random() * this.phrases[key].length);
+    phrase = this.phrases[key][random];
   } else if (typeof opts._ === 'string') {
     phrase = opts._;
   } else if (this.onMissingKey) {

--- a/test/index.js
+++ b/test/index.js
@@ -129,6 +129,17 @@ describe('t', function () {
     expect(instance.t('header.sign_in')).to.equal('Sign In');
   });
 
+  it('supports array phrases', function () {
+    var helloArray = ['Hi', 'Welcome', 'Hello'];
+
+    var arrayPhrases = {
+      hello: helloArray
+    };
+
+    var instance = new Polyglot({ phrases: arrayPhrases });
+    expect(helloArray).to.include(instance.t('hello'));
+  });
+
   describe('onMissingKey', function () {
     it('calls the function when a key is missing', function () {
       var expectedKey = 'some key';


### PR DESCRIPTION
## What

Add support for picking a random value from an array of phrases.

For example:

```js
var phrases = {
  hello: ['Hi', 'Welcome', 'Hello'], 
}

var polyglot = new Polyglot({ phrases: phrases })
console.log(polyglot.t('hello')) // Hi
console.log(polyglot.t('hello')) // Welcome
console.log(polyglot.t('hello') // Hi 
console.log(polyglot.t('hello') // Hello
```

## Why

I stumbled upon a use-case lately while building a chatbot. One of the best practices of conversational design is to tell the user different sentences so that the conversation feels more natural.
The best solution that came to me was to pick a random value from an array and then translate it.
As there are no other uses of array of phrases in Polyglot, I thought it would be a good addition to it.

## Changes 

- Add support for picking a random value from an array of phrases in the `t` method.
- Add a test case that makes sure the translated key is in the array of phrases provided to Polyglot.
