### PR TITLE
Remove unnecessary dollar signs replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,8 +144,6 @@ function constructTokenRegex(opts) {
   return new RegExp(escape(prefix) + '(.*?)' + escape(suffix), 'g');
 }
 
-var dollarRegex = /\$/g;
-var dollarBillsYall = '$$';
 var defaultTokenRegex = /%\{(.*?)\}/g;
 
 // ### transformPhrase(phrase, substitutions, locale)
@@ -197,8 +195,7 @@ function transformPhrase(phrase, substitutions, locale, tokenRegex) {
   // Interpolate: Creates a `RegExp` object for each interpolation placeholder.
   result = replace.call(result, interpolationRegex, function (expression, argument) {
     if (!has(options, argument) || options[argument] == null) { return expression; }
-    // Ensure replacement value is escaped to prevent special $-prefixed regex replace tokens.
-    return replace.call(options[argument], dollarRegex, dollarBillsYall);
+    return options[argument];
   });
 
   return result;


### PR DESCRIPTION
If I'm not mistaken, the function form of `String.prototype.replace` does not apply the special replacement patterns such as `$$`, `$&`, etc. Thus, it makes the $-prefixed regex replacement unnecessary in this case.

[MDN Source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter)