### PR TITLE
Rework locale specific pluralization rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,79 +33,212 @@ var split = String.prototype.split;
 // The string that separates the different phrase possibilities.
 var delimiter = '||||';
 
-var russianPluralGroups = function (n) {
-  var lastTwo = n % 100;
-  var end = lastTwo % 10;
-  if (lastTwo !== 11 && end === 1) {
-    return 0;
-  }
-  if (2 <= end && end <= 4 && !(lastTwo >= 12 && lastTwo <= 14)) {
-    return 1;
-  }
-  return 2;
-};
-
 // Mapping from pluralization group plural logic.
 var pluralTypes = {
-  arabic: function (n) {
-    // http://www.arabeyes.org/Plural_Forms
-    if (n < 3) { return n; }
-    var lastTwo = n % 100;
-    if (lastTwo >= 3 && lastTwo <= 10) return 3;
-    return lastTwo >= 11 ? 4 : 5;
+  chineseLike: function () {
+    return 0;
   },
-  bosnian_serbian: russianPluralGroups,
-  chinese: function () { return 0; },
-  croatian: russianPluralGroups,
-  french: function (n) { return n > 1 ? 1 : 0; },
-  german: function (n) { return n !== 1 ? 1 : 0; },
-  russian: russianPluralGroups,
-  lithuanian: function (n) {
-    if (n % 10 === 1 && n % 100 !== 11) { return 0; }
-    return n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19) ? 1 : 2;
-  },
-  czech: function (n) {
-    if (n === 1) { return 0; }
-    return (n >= 2 && n <= 4) ? 1 : 2;
-  },
-  polish: function (n) {
-    if (n === 1) { return 0; }
-    var end = n % 10;
-    return 2 <= end && end <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2;
-  },
-  icelandic: function (n) { return (n % 10 !== 1 || n % 100 === 11) ? 1 : 0; },
-  slovenian: function (n) {
-    var lastTwo = n % 100;
-    if (lastTwo === 1) {
+  germanLike: function (n) {
+    // is 1
+    if (n === 1) {
       return 0;
     }
-    if (lastTwo === 2) {
+    // everything else
+    return 1;
+  },
+  frenchLike: function (n) {
+    // is 0 or 1
+    if (n <= 1) {
+      return 0;
+    }
+    // everything else
+    return 1;
+  },
+  russianLike: function (n) {
+    // ends in 1, excluding 11
+    if (n % 10 === 1 && n % 100 !== 11) {
+      return 0;
+    }
+    // ends in 2-4, excluding 12-14
+    if (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) {
       return 1;
     }
-    if (lastTwo === 3 || lastTwo === 4) {
+    // everything else
+    return 2;
+  },
+  czechLike: function (n) {
+    // is 1
+    if (n === 1) {
+      return 0;
+    }
+    // is 2-4
+    if (n >= 2 && n <= 4) {
+      return 1;
+    }
+    // everything else
+    return 2;
+  },
+  polishLike: function (n) {
+    // is 1
+    if (n === 1) {
+      return 0;
+    }
+    // ends in 2-4, excluding 12-14
+    if (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) {
+      return 1;
+    }
+    // everything else
+    return 2;
+  },
+  icelandicLike: function (n) {
+    // ends in 1, excluding 11
+    if (n % 10 === 1 && n % 100 !== 11) {
+      return 0;
+    }
+    // everything else
+    return 1;
+  },
+  arabicLike: function (n) {
+    // is 0
+    if (n === 0) {
+      return 0;
+    }
+    // is 1
+    if (n === 1) {
+      return 1;
+    }
+    // is 2
+    if (n === 2) {
       return 2;
     }
+    // ends in 03-10
+    if (n % 100 >= 3 && n % 100 <= 10) {
+      return 3;
+    }
+    // everything else but is 0 and ends in 00-02, excluding 0-2
+    if (n % 100 >= 11) {
+      return 4;
+    }
+    // everything else
+    return 5;
+  },
+  irish: function (n) {
+    // is 1
+    if (n === 1) {
+      return 0;
+    }
+    // is 2
+    if (n === 2) {
+      return 1;
+    }
+    // is 3-6
+    if (n >= 3 && n <= 6) {
+      return 2;
+    }
+    // is 7-10
+    if (n >= 7 && n <= 10) {
+      return 3;
+    }
+    // everything else
+    return 4;
+  },
+  latvianLike: function (n) {
+    // ends in 0
+    if (n % 10 === 0) {
+      return 0;
+    }
+    // ends in 1, excluding 11
+    if (n % 10 === 1 && n % 100 !== 11) {
+      return 1;
+    }
+    // everything else
+    return 2;
+  },
+  lithuanian: function (n) {
+    // ends in 1, excluding 11
+    if (n % 10 === 1 && n % 100 !== 11) {
+      return 0;
+    }
+    // ends in 0 or ends in 11-19
+    if (n % 10 === 0 || (n % 100 >= 11 && n % 100 <= 19)) {
+      return 1;
+    }
+    // everything else
+    return 2;
+  },
+  maltese: function (n) {
+    // is 1
+    if (n === 1) {
+      return 0;
+    }
+    // is 0 or ends in 01-10, excluding 1
+    if (n === 0 || (n !== 1 && n % 100 >= 1 && n % 100 <= 10)) {
+      return 1;
+    }
+    // ends in 11-19
+    if (n % 100 >= 11 && n % 100 <= 19) {
+      return 2;
+    }
+    // everything else
     return 3;
+  },
+  romanian: function (n) {
+    // is 1
+    if (n === 1) {
+      return 0;
+    }
+    // is 0 or ends in 01-19, excluding 1
+    if (n === 0 || (n !== 1 && n % 100 >= 1 && n % 100 <= 19)) {
+      return 1;
+    }
+    // everything else
+    return 2;
+  },
+  slovenianLike: function (n) {
+    // ends in 01
+    if (n % 100 === 1) {
+      return 0;
+    }
+    // ends in 02
+    if (n % 100 === 2) {
+      return 1;
+    }
+    // ends in 03-04
+    if (n % 100 === 3 || n % 100 === 4) {
+      return 2;
+    }
+    // everything else
+    return 3;
+  },
+  tagalog: function (n) {
+    // ends in 0, 1, 2, 3, 5, 7, 8
+    if (n % 10 !== 4 && n % 10 !== 6 && n % 10 !== 9) {
+      return 0;
+    }
+    // everything else
+    return 1;
   }
 };
-
 
 // Mapping from pluralization group to individual language codes/locales.
 // Will look up based on exact match, if not found and it's a locale will parse the locale
 // for language code, and if that does not exist will default to 'en'
 var pluralTypeToLanguages = {
-  arabic: ['ar'],
-  bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
-  chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
-  croatian: ['hr', 'hr-HR'],
-  german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],
-  french: ['fr', 'tl', 'pt-br'],
-  russian: ['ru', 'ru-RU'],
+  chineseLike: ['az', 'id', 'ja', 'ko', 'lo', 'ms', 'th', 'tr', 'vi', 'zh', 'zh-TW'],
+  germanLike: ['bg', 'ca', 'da', 'de', 'el', 'en', 'es', 'et', 'fa', 'fi', 'he', 'hu', 'it', 'ka', 'nl', 'no', 'pt', 'sq', 'sv', 'sw', 'xh', 'zu'],
+  frenchLike: ['fr', 'hi', 'hy', 'pt-BR', 'pt-br'],
+  russianLike: ['bs', 'hr', 'ru', 'sr', 'srl', 'uk'],
+  czechLike: ['cs', 'sk'],
+  polishLike: ['pl'],
+  icelandicLike: ['is', 'mk'],
+  arabicLike: ['ar'],
+  irish: ['ga'],
+  latvianLike: ['lv'],
   lithuanian: ['lt'],
-  czech: ['cs', 'cs-CZ', 'sk'],
-  polish: ['pl'],
-  icelandic: ['is'],
-  slovenian: ['sl-SL']
+  maltese: ['mt'],
+  romanian: ['ro'],
+  slovenianLike: ['sl'],
+  tagalog: ['tl']
 };
 
 function langToTypeMap(mapping) {

--- a/test/index.js
+++ b/test/index.js
@@ -450,44 +450,241 @@ describe('locale-specific pluralization rules', function () {
       expect(polyglot.t('n_votes', c)).to.equal(c + ' komentarjev');
     });
   });
+});
 
-  it('pluralizes in Turkish', function () {
-    var whatSomeoneTranslated = [
-      'Sepetinizde %{smart_count} X var. Bunu almak istiyor musunuz?',
-      'Sepetinizde %{smart_count} X var. Bunları almak istiyor musunuz?'
-    ];
-    var phrases = {
-      n_x_cart: whatSomeoneTranslated.join(' |||| ')
-    };
+describe('locale-specific pluralization rules exhaustive', function () {
+  function testPlurals(text, locale, answers) {
+    var polyglot = new Polyglot({ phrases: { test_phrase: text }, locale: locale });
 
-    var polyglot = new Polyglot({ phrases: phrases, locale: 'tr' });
+    answers.forEach(function (answer, i) {
+      var expected = answer.replace('%{smart_count}', i);
+      expect(polyglot.t('test_phrase', i)).to.equal(expected);
+    });
+  }
 
-    expect(polyglot.t('n_x_cart', 1)).to.equal('Sepetinizde 1 X var. Bunu almak istiyor musunuz?');
-    expect(polyglot.t('n_x_cart', 2)).to.equal('Sepetinizde 2 X var. Bunları almak istiyor musunuz?');
+  function expandAnswers(condensedAnswers) {
+    var answers = [];
+    condensedAnswers.forEach(function (condensedAnswer) {
+      var answer = condensedAnswer[0];
+      var reps = condensedAnswer[1];
+
+      for (var i = 0; i < reps; i += 1) {
+        answers.push(answer);
+      }
+    });
+
+    return answers;
+  }
+
+  it('pluralizes in ja', function () {
+    var reviewText = '%{smart_count} レビュー';
+
+    var answers = expandAnswers([
+      ['%{smart_count} レビュー', 26]
+    ]);
+
+    testPlurals(reviewText, 'ja', answers);
   });
 
-  it('pluralizes in Lithuanian', function () {
-    var whatSomeoneTranslated = [
-      '%{smart_count} balsas',
-      '%{smart_count} balsai',
-      '%{smart_count} balsų'
-    ];
-    var phrases = {
-      n_votes: whatSomeoneTranslated.join(' |||| ')
-    };
-    var polyglot = new Polyglot({ phrases: phrases, locale: 'lt' });
+  it('pluralizes in zh-TW', function () {
+    var reviewText = '%{smart_count} 台灣飯店';
 
-    expect(polyglot.t('n_votes', 0)).to.equal('0 balsų');
-    expect(polyglot.t('n_votes', 1)).to.equal('1 balsas');
-    expect(polyglot.t('n_votes', 2)).to.equal('2 balsai');
-    expect(polyglot.t('n_votes', 9)).to.equal('9 balsai');
-    expect(polyglot.t('n_votes', 10)).to.equal('10 balsų');
-    expect(polyglot.t('n_votes', 11)).to.equal('11 balsų');
-    expect(polyglot.t('n_votes', 12)).to.equal('12 balsų');
-    expect(polyglot.t('n_votes', 90)).to.equal('90 balsų');
-    expect(polyglot.t('n_votes', 91)).to.equal('91 balsas');
-    expect(polyglot.t('n_votes', 92)).to.equal('92 balsai');
-    expect(polyglot.t('n_votes', 102)).to.equal('102 balsai');
+    var answers = expandAnswers([
+      ['%{smart_count} 台灣飯店', 26]
+    ]);
+
+    testPlurals(reviewText, 'zh-TW', answers);
+  });
+
+  it('pluralizes in de', function () {
+    var reviewText = '%{smart_count} bewertung |||| %{smart_count} bewertungen';
+
+    var answers = expandAnswers([
+      ['%{smart_count} bewertungen', 1],
+      ['%{smart_count} bewertung', 1],
+      ['%{smart_count} bewertungen', 24]
+    ]);
+
+    testPlurals(reviewText, 'de', answers);
+  });
+
+  it('pluralizes in fr', function () {
+    var reviewText = '%{smart_count} commentaire |||| %{smart_count} commentaires';
+
+    var answers = expandAnswers([
+      ['%{smart_count} commentaire', 2],
+      ['%{smart_count} commentaires', 24]
+    ]);
+
+    testPlurals(reviewText, 'fr', answers);
+  });
+
+  it('pluralizes in ru', function () {
+    var reviewText = '%{smart_count} ends-in-one-except-eleven |||| %{smart_count} ends-in-two-through-four-except-twelve-through-fourteen |||| %{smart_count} everything-else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} everything-else', 1],
+      ['%{smart_count} ends-in-one-except-eleven', 1],
+      ['%{smart_count} ends-in-two-through-four-except-twelve-through-fourteen', 3],
+      ['%{smart_count} everything-else', 16],
+      ['%{smart_count} ends-in-one-except-eleven', 1],
+      ['%{smart_count} ends-in-two-through-four-except-twelve-through-fourteen', 3],
+      ['%{smart_count} everything-else', 1]
+    ]);
+
+    testPlurals(reviewText, 'ru', answers);
+  });
+
+  it('pluralizes in ar', function () {
+    var reviewText = '%{smart_count} zero |||| %{smart_count} one |||| %{smart_count} two |||| %{smart_count} ends-in-03-10 |||| %{smart_count} ends-in-11-99 |||| %{smart_count} ends-in-00-01-02';
+
+    var answers = expandAnswers([
+      ['%{smart_count} zero', 1],
+      ['%{smart_count} one', 1],
+      ['%{smart_count} two', 1],
+      ['%{smart_count} ends-in-03-10', 8],
+      ['%{smart_count} ends-in-11-99', 89],
+      ['%{smart_count} ends-in-00-01-02', 3],
+      ['%{smart_count} ends-in-03-10', 8],
+      ['%{smart_count} ends-in-11-99', 89],
+      ['%{smart_count} ends-in-00-01-02', 3],
+      ['%{smart_count} ends-in-03-10', 8],
+      ['%{smart_count} ends-in-11-99', 89]
+    ]);
+
+    testPlurals(reviewText, 'ar', answers);
+  });
+
+  it('pluralizes in cs', function () {
+    var reviewText = '%{smart_count} one |||| %{smart_count} two-through-four |||| %{smart_count} everything-else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} everything-else', 1],
+      ['%{smart_count} one', 1],
+      ['%{smart_count} two-through-four', 3],
+      ['%{smart_count} everything-else', 21]
+    ]);
+
+    testPlurals(reviewText, 'cs', answers);
+  });
+
+  it('pluralizes in pl', function () {
+    var reviewText = '%{smart_count} one |||| %{smart_count} ends-in-two-through-four-except-twelve-through-fourteen |||| %{smart_count} everything-else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} everything-else', 1],
+      ['%{smart_count} one', 1],
+      ['%{smart_count} ends-in-two-through-four-except-twelve-through-fourteen', 3],
+      ['%{smart_count} everything-else', 17],
+      ['%{smart_count} ends-in-two-through-four-except-twelve-through-fourteen', 3],
+      ['%{smart_count} everything-else', 1]
+    ]);
+
+    testPlurals(reviewText, 'pl', answers);
+  });
+
+  it('pluralizes in ga', function () {
+    var reviewText = '%{smart_count} one |||| %{smart_count} two |||| %{smart_count} three to six |||| %{smart_count} seven to ten |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} everything else', 1],
+      ['%{smart_count} one', 1],
+      ['%{smart_count} two', 1],
+      ['%{smart_count} three to six', 4],
+      ['%{smart_count} seven to ten', 4],
+      ['%{smart_count} everything else', 10]
+    ]);
+
+    testPlurals(reviewText, 'ga', answers);
+  });
+
+  it('pluralizes in lv', function () {
+    var reviewText = '%{smart_count} ends in 0 |||| %{smart_count} ends in 1, excluding 11 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} ends in 0', 1],
+      ['%{smart_count} ends in 1, excluding 11', 1],
+      ['%{smart_count} everything else', 8],
+      ['%{smart_count} ends in 0', 1],
+      ['%{smart_count} everything else', 9],
+      ['%{smart_count} ends in 0', 1],
+      ['%{smart_count} ends in 1, excluding 11', 1],
+      ['%{smart_count} everything else', 8]
+    ]);
+
+    testPlurals(reviewText, 'lv', answers);
+  });
+
+  it('pluralizes in lt', function () {
+    var reviewText = '%{smart_count} ends in 1, excluding 11 |||| %{smart_count} ends in 0 or ends in 11-19 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} ends in 0 or ends in 11-19', 1],
+      ['%{smart_count} ends in 1, excluding 11', 1],
+      ['%{smart_count} everything else', 8],
+      ['%{smart_count} ends in 0 or ends in 11-19', 11],
+      ['%{smart_count} ends in 1, excluding 11', 1],
+      ['%{smart_count} everything else', 8]
+    ]);
+
+    testPlurals(reviewText, 'lt', answers);
+  });
+
+  it('pluralizes in mt', function () {
+    var reviewText = '%{smart_count} is 1 |||| %{smart_count} is 0 or ends in 01-10 excluding 1 |||| %{smart_count} ends in 11-19 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} is 0 or ends in 01-10 excluding 1', 1],
+      ['%{smart_count} is 1', 1],
+      ['%{smart_count} is 0 or ends in 01-10 excluding 1', 9],
+      ['%{smart_count} ends in 11-19', 9],
+      ['%{smart_count} everything else', 10]
+    ]);
+
+    testPlurals(reviewText, 'mt', answers);
+  });
+
+  it('pluralizes in ro', function () {
+    var reviewText = '%{smart_count} is 1 |||| %{smart_count} is 0 or ends in 01-19, excluding 1 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} is 0 or ends in 01-19, excluding 1', 1],
+      ['%{smart_count} is 1', 1],
+      ['%{smart_count} is 0 or ends in 01-19, excluding 1', 18],
+      ['%{smart_count} everything else', 10]
+    ]);
+
+    testPlurals(reviewText, 'ro', answers);
+  });
+
+  it('pluralizes in sl', function () {
+    var reviewText = '%{smart_count} ends in 01 |||| %{smart_count} ends in 02 |||| %{smart_count} ends in 03-04 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} everything else', 1],
+      ['%{smart_count} ends in 01', 1],
+      ['%{smart_count} ends in 02', 1],
+      ['%{smart_count} ends in 03-04', 2],
+      ['%{smart_count} everything else', 16]
+    ]);
+
+    testPlurals(reviewText, 'sl', answers);
+  });
+
+  it('pluralizes in tl', function () {
+    var reviewText = '%{smart_count} ends in 0, 1, 2, 3, 5, 7, 8 |||| %{smart_count} everything else';
+
+    var answers = expandAnswers([
+      ['%{smart_count} ends in 0, 1, 2, 3, 5, 7, 8', 4],
+      ['%{smart_count} everything else', 1],
+      ['%{smart_count} ends in 0, 1, 2, 3, 5, 7, 8', 1],
+      ['%{smart_count} everything else', 1],
+      ['%{smart_count} ends in 0, 1, 2, 3, 5, 7, 8', 2],
+      ['%{smart_count} everything else', 1],
+      ['%{smart_count} ends in 0, 1, 2, 3, 5, 7, 8', 4]
+    ]);
+
+    testPlurals(reviewText, 'tl', answers);
   });
 });
 


### PR DESCRIPTION
I regenerated pluralization rules according to internal sources that are
used in our non-JavaScript environments. This is needed to ensure
consistency between translations regardless of platform. The plural rule
functions were automatically generated from a Java source, so they are
somewhat more verbose and less hand-factored.

Names of plural types are purely mnemonic and do not imply a specific
relationship between two languages, only that their pluralType functions
would be the same.

Polyglot supports locales that we don't use internally that were
contributed by the community. I've ported those over to maintain
compatibility. There were several places where exact locales were
specified. I changed those to be based on language-only when doing so
would not change the result. Behavior for pt-BR is preserved, as it does
have a different pluralization rule than pt.

There were a couple areas of disagreement between sources. In these
cases, I went with what we were using internally, which tends to be close to
https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_and_Plurals

The specific changes in this PR are

1. tr from germanLike to chineseLike
2. lt rule changed
3. tl from frenchLike to tagalog

Additionally, per our records, fa would be chineseLike instead of
germanLike, but as we do not yet support this language, I have left it
as is.

I also generated tests based on some other pluralization specs we had in a different implementation.

/cc @mereskin-zz 