### PR TITLE
Make pluralization rules configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ polyglot.extend({
 
 In English (and German, Spanish, Italian, and a few others) there are only two plural forms: singular and not-singular.
 
-Some languages get a bit more complicated. In Czech, there are three separate forms: 1, 2 through 4, and 5 and up. Russian is even crazier.
+Some languages get a bit more complicated. In Czech, there are three separate forms: 1, 2 through 4, and 5 and up. Russian is even more involved.
 
 ```js
 var polyglot = new Polyglot({locale: "cs"}); // Czech
@@ -194,6 +194,41 @@ As a shortcut, you can also pass a number to the second parameter:
 polyglot.t("num_cars", 2);
 => "2 cars"
 ```
+
+#### Custom Pluralization Rules
+
+Polyglot provides some default pluralization rules for some locales. You can specify a different set of rules through the `pluralRules` constructor param.
+
+```js
+var polyglot = new Polyglot({
+  pluralRules: {
+    pluralTypes: {
+      germanLike: function (n) {
+        // is 1
+        if (n === 1) {
+          return 0;
+        }
+        // everything else
+        return 1;
+      },
+      frenchLike: function (n) {
+        // is 0 or 1
+        if (n <= 1) {
+          return 0;
+        }
+        // everything else
+        return 1;
+      }
+    },
+    pluralTypeToLanguages: {
+      germanLike: ['de', 'en', 'xh', 'zu'],
+      frenchLike: ['fr', 'hy']
+    }
+  }
+});
+```
+
+This can be useful to support locales that polyglot does not support by default or to change the rule definitions.
 
 ## Public Instance Methods
 
@@ -299,6 +334,7 @@ You should pass in a third argument, the locale, to specify the correct plural t
  - `allowMissing`: a boolean to control whether missing keys in a `t` call are allowed. If `false`, by default, a missing key is returned and a warning is issued.
  - `onMissingKey`: if `allowMissing` is `true`, and this option is a function, then it will be called instead of the default functionality. Arguments passed to it are `key`, `options`, and `locale`. The return of this function will be used as a translation fallback when `polyglot.t('missing.key')` is called (hint: return the key).
  - `interpolation`: an object to change the substitution syntax for interpolation by setting the `prefix` and `suffix` fields.
+ - `pluralRules`: an object of `pluralTypes` and `pluralTypeToLanguages` to control pluralization logic.
 
 
 ## [History](CHANGELOG.md)

--- a/index.js
+++ b/index.js
@@ -45,67 +45,68 @@ var russianPluralGroups = function (n) {
   return 2;
 };
 
-// Mapping from pluralization group plural logic.
-var pluralTypes = {
-  arabic: function (n) {
-    // http://www.arabeyes.org/Plural_Forms
-    if (n < 3) { return n; }
-    var lastTwo = n % 100;
-    if (lastTwo >= 3 && lastTwo <= 10) return 3;
-    return lastTwo >= 11 ? 4 : 5;
-  },
-  bosnian_serbian: russianPluralGroups,
-  chinese: function () { return 0; },
-  croatian: russianPluralGroups,
-  french: function (n) { return n > 1 ? 1 : 0; },
-  german: function (n) { return n !== 1 ? 1 : 0; },
-  russian: russianPluralGroups,
-  lithuanian: function (n) {
-    if (n % 10 === 1 && n % 100 !== 11) { return 0; }
-    return n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19) ? 1 : 2;
-  },
-  czech: function (n) {
-    if (n === 1) { return 0; }
-    return (n >= 2 && n <= 4) ? 1 : 2;
-  },
-  polish: function (n) {
-    if (n === 1) { return 0; }
-    var end = n % 10;
-    return 2 <= end && end <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2;
-  },
-  icelandic: function (n) { return (n % 10 !== 1 || n % 100 === 11) ? 1 : 0; },
-  slovenian: function (n) {
-    var lastTwo = n % 100;
-    if (lastTwo === 1) {
-      return 0;
+var defaultPluralRules = {
+  // Mapping from pluralization group plural logic.
+  pluralTypes: {
+    arabic: function (n) {
+      // http://www.arabeyes.org/Plural_Forms
+      if (n < 3) { return n; }
+      var lastTwo = n % 100;
+      if (lastTwo >= 3 && lastTwo <= 10) return 3;
+      return lastTwo >= 11 ? 4 : 5;
+    },
+    bosnian_serbian: russianPluralGroups,
+    chinese: function () { return 0; },
+    croatian: russianPluralGroups,
+    french: function (n) { return n > 1 ? 1 : 0; },
+    german: function (n) { return n !== 1 ? 1 : 0; },
+    russian: russianPluralGroups,
+    lithuanian: function (n) {
+      if (n % 10 === 1 && n % 100 !== 11) { return 0; }
+      return n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19) ? 1 : 2;
+    },
+    czech: function (n) {
+      if (n === 1) { return 0; }
+      return (n >= 2 && n <= 4) ? 1 : 2;
+    },
+    polish: function (n) {
+      if (n === 1) { return 0; }
+      var end = n % 10;
+      return 2 <= end && end <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2;
+    },
+    icelandic: function (n) { return (n % 10 !== 1 || n % 100 === 11) ? 1 : 0; },
+    slovenian: function (n) {
+      var lastTwo = n % 100;
+      if (lastTwo === 1) {
+        return 0;
+      }
+      if (lastTwo === 2) {
+        return 1;
+      }
+      if (lastTwo === 3 || lastTwo === 4) {
+        return 2;
+      }
+      return 3;
     }
-    if (lastTwo === 2) {
-      return 1;
-    }
-    if (lastTwo === 3 || lastTwo === 4) {
-      return 2;
-    }
-    return 3;
+  },
+
+  // Mapping from pluralization group to individual language codes/locales.
+  // Will look up based on exact match, if not found and it's a locale will parse the locale
+  // for language code, and if that does not exist will default to 'en'
+  pluralTypeToLanguages: {
+    arabic: ['ar'],
+    bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
+    chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
+    croatian: ['hr', 'hr-HR'],
+    german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],
+    french: ['fr', 'tl', 'pt-br'],
+    russian: ['ru', 'ru-RU'],
+    lithuanian: ['lt'],
+    czech: ['cs', 'cs-CZ', 'sk'],
+    polish: ['pl'],
+    icelandic: ['is'],
+    slovenian: ['sl-SL']
   }
-};
-
-
-// Mapping from pluralization group to individual language codes/locales.
-// Will look up based on exact match, if not found and it's a locale will parse the locale
-// for language code, and if that does not exist will default to 'en'
-var pluralTypeToLanguages = {
-  arabic: ['ar'],
-  bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
-  chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
-  croatian: ['hr', 'hr-HR'],
-  german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],
-  french: ['fr', 'tl', 'pt-br'],
-  russian: ['ru', 'ru-RU'],
-  lithuanian: ['lt'],
-  czech: ['cs', 'cs-CZ', 'sk'],
-  polish: ['pl'],
-  icelandic: ['is'],
-  slovenian: ['sl-SL']
 };
 
 function langToTypeMap(mapping) {
@@ -118,15 +119,15 @@ function langToTypeMap(mapping) {
   return ret;
 }
 
-function pluralTypeName(locale) {
-  var langToPluralType = langToTypeMap(pluralTypeToLanguages);
+function pluralTypeName(pluralRules, locale) {
+  var langToPluralType = langToTypeMap(pluralRules.pluralTypeToLanguages);
   return langToPluralType[locale]
     || langToPluralType[split.call(locale, /-/, 1)[0]]
     || langToPluralType.en;
 }
 
-function pluralTypeIndex(locale, count) {
-  return pluralTypes[pluralTypeName(locale)](count);
+function pluralTypeIndex(pluralRules, locale, count) {
+  return pluralRules.pluralTypes[pluralTypeName(pluralRules, locale)](count);
 }
 
 function escape(token) {
@@ -169,7 +170,7 @@ var defaultTokenRegex = /%\{(.*?)\}/g;
 //
 // You should pass in a third argument, the locale, to specify the correct plural type.
 // It defaults to `'en'` with 2 plural forms.
-function transformPhrase(phrase, substitutions, locale, tokenRegex) {
+function transformPhrase(phrase, substitutions, locale, tokenRegex, pluralRules) {
   if (typeof phrase !== 'string') {
     throw new TypeError('Polyglot.transformPhrase expects argument #1 to be string');
   }
@@ -180,6 +181,7 @@ function transformPhrase(phrase, substitutions, locale, tokenRegex) {
 
   var result = phrase;
   var interpolationRegex = tokenRegex || defaultTokenRegex;
+  var pluralRulesOrDefault = pluralRules || defaultPluralRules;
 
   // allow number as a pluralization shortcut
   var options = typeof substitutions === 'number' ? { smart_count: substitutions } : substitutions;
@@ -189,7 +191,7 @@ function transformPhrase(phrase, substitutions, locale, tokenRegex) {
   // choose the correct plural form. This is only done if `count` is set.
   if (options.smart_count != null && result) {
     var texts = split.call(result, delimiter);
-    result = trim(texts[pluralTypeIndex(locale || 'en', options.smart_count)] || texts[0]);
+    result = trim(texts[pluralTypeIndex(pluralRulesOrDefault, locale || 'en', options.smart_count)] || texts[0]);
   }
 
   // Interpolate: Creates a `RegExp` object for each interpolation placeholder.
@@ -211,6 +213,7 @@ function Polyglot(options) {
   this.onMissingKey = typeof opts.onMissingKey === 'function' ? opts.onMissingKey : allowMissing;
   this.warn = opts.warn || warn;
   this.tokenRegex = constructTokenRegex(opts.interpolation);
+  this.pluralRules = opts.pluralRules || defaultPluralRules;
 }
 
 // ### polyglot.locale([locale])
@@ -361,13 +364,13 @@ Polyglot.prototype.t = function (key, options) {
     phrase = opts._;
   } else if (this.onMissingKey) {
     var onMissingKey = this.onMissingKey;
-    result = onMissingKey(key, opts, this.currentLocale, this.tokenRegex);
+    result = onMissingKey(key, opts, this.currentLocale, this.tokenRegex, this.pluralRules);
   } else {
     this.warn('Missing translation for key: "' + key + '"');
     result = key;
   }
   if (typeof phrase === 'string') {
-    result = transformPhrase(phrase, opts, this.currentLocale, this.tokenRegex);
+    result = transformPhrase(phrase, opts, this.currentLocale, this.tokenRegex, this.pluralRules);
   }
   return result;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -491,6 +491,61 @@ describe('locale-specific pluralization rules', function () {
   });
 });
 
+describe('custom pluralRules', function () {
+  var customPluralRules = {
+    pluralTypes: {
+      germanLike: function (n) {
+        // is 1
+        if (n === 1) {
+          return 0;
+        }
+        // everything else
+        return 1;
+      },
+      frenchLike: function (n) {
+        // is 0 or 1
+        if (n <= 1) {
+          return 0;
+        }
+        // everything else
+        return 1;
+      }
+    },
+    pluralTypeToLanguages: {
+      germanLike: ['x1'],
+      frenchLike: ['x2']
+    }
+  };
+
+  var testPhrases = {
+    test_phrase: '%{smart_count} form zero |||| %{smart_count} form one'
+  };
+
+  it('pluralizes in x1', function () {
+    var polyglot = new Polyglot({
+      phrases: testPhrases,
+      locale: 'x1',
+      pluralRules: customPluralRules
+    });
+
+    expect(polyglot.t('test_phrase', 0)).to.equal('0 form one');
+    expect(polyglot.t('test_phrase', 1)).to.equal('1 form zero');
+    expect(polyglot.t('test_phrase', 2)).to.equal('2 form one');
+  });
+
+  it('pluralizes in x2', function () {
+    var polyglot = new Polyglot({
+      phrases: testPhrases,
+      locale: 'x2',
+      pluralRules: customPluralRules
+    });
+
+    expect(polyglot.t('test_phrase', 0)).to.equal('0 form zero');
+    expect(polyglot.t('test_phrase', 1)).to.equal('1 form zero');
+    expect(polyglot.t('test_phrase', 2)).to.equal('2 form one');
+  });
+});
+
 describe('locale', function () {
   var polyglot;
   beforeEach(function () {


### PR DESCRIPTION
Users may wish to support different locales without requiring a change
or fork to the library. Additionally, some users may prefer slightly
different pluralization rules for some locales.

Follow up to https://github.com/airbnb/polyglot.js/pull/137

/cc @ljharb @mereskin-zz 