### PR TITLE
Remove string trim polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@
 var forEach = require('for-each');
 var warning = require('warning');
 var has = require('has');
-var trim = require('string.prototype.trim');
 
 var warn = function warn(message) {
   warning(false, message);
@@ -191,7 +190,7 @@ function transformPhrase(phrase, substitutions, locale, tokenRegex, pluralRules)
   // choose the correct plural form. This is only done if `count` is set.
   if (options.smart_count != null && result) {
     var texts = split.call(result, delimiter);
-    result = trim(texts[pluralTypeIndex(pluralRulesOrDefault, locale || 'en', options.smart_count)] || texts[0]);
+    result = (texts[pluralTypeIndex(pluralRulesOrDefault, locale || 'en', options.smart_count)] || texts[0]).trim();
   }
 
   // Interpolate: Creates a `RegExp` object for each interpolation placeholder.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "for-each": "^0.3.3",
     "has": "^1.0.3",
-    "string.prototype.trim": "^1.1.2",
     "warning": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This library is actually quite large (21.6kb https://bundlephobia.com/result?p=node-polyglot@2.4.0). This is due to the String.prototype.trim polyfill, and it's dependencies (mainly es-abstract).

String.prototype.trim has been supported by all major browsers for nearly 10 years https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim so it's probably not worth including in the library.

By removing it, it should save just over 15kb of minified JS (according to bundlephobia).

Dependencies before:
https://bundlephobia.com/scan-results?packages=for-each@0.3.3,has@1.0.3,string.prototype.trim@1.1.2,warning@4.0.3

Dependencies after:
https://bundlephobia.com/scan-results?packages=for-each@0.3.3,has@1.0.3,warning@4.0.3

