### PR TITLE
docs: Fix simple typo, documention -> documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 //     (c) 2012-2018 Airbnb, Inc.
 //
 //     polyglot.js may be freely distributed under the terms of the BSD
-//     license. For all licensing information, details, and documention:
+//     license. For all licensing information, details, and documentation:
 //     http://airbnb.github.com/polyglot.js
 //
 //


### PR DESCRIPTION
There is a small typo in index.js.

Should read `documentation` rather than `documention`.

