### PR TITLE
Add main code for Serbian language

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ var defaultPluralRules = {
       if (lastTwo >= 3 && lastTwo <= 10) return 3;
       return lastTwo >= 11 ? 4 : 5;
     },
-    bosnian_serbian: russianPluralGroups,
+    serbian: russianPluralGroups,
+    bosnian: russianPluralGroups,
     chinese: function () { return 0; },
     croatian: russianPluralGroups,
     french: function (n) { return n > 1 ? 1 : 0; },
@@ -95,7 +96,8 @@ var defaultPluralRules = {
   // for language code, and if that does not exist will default to 'en'
   pluralTypeToLanguages: {
     arabic: ['ar'],
-    bosnian_serbian: ['bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS'],
+    serbian: ['sr', 'sr-Cyrl', 'sr-Latn', 'sr-RS'],
+    bosnian: ['bs', 'bs-Cyrl', 'bs-Latn', 'bs-BA'],
     chinese: ['id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh'],
     croatian: ['hr', 'hr-HR'],
     german: ['fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr'],


### PR DESCRIPTION
Language tag, According to [IETF Language tags](https://en.wikipedia.org/wiki/IETF_language_tag), can be composed of primary language tag, script tag and region tag (among some other, rarely used tags).

Main code for Serbian, by [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), is `sr`.

Serbian and Bosnian have two scripts, latin and cyrillic, so I added those also, as in [ISO 15924](https://en.wikipedia.org/wiki/ISO_15924).

I also added, for both languages, region tag (`sr-RS` and `bs-BA`), as in [ISO 3166-1 alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) although I am not sure those are needed, but Croatian have that so why not ;)

Serbian, Croatian, Bosnian and Montenegrin are basically same languages but, officially, they are different, so I separated them here.