### PR TITLE
remove dependencies unnecessary in now-old browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@
 var forEach = require('for-each');
 var warning = require('warning');
 var has = require('has');
-var trim = require('string.prototype.trim');
 
 var warn = function warn(message) {
   warning(false, message);
@@ -191,7 +190,7 @@ function transformPhrase(phrase, substitutions, locale, tokenRegex, pluralRules)
   // choose the correct plural form. This is only done if `count` is set.
   if (options.smart_count != null && result) {
     var texts = split.call(result, delimiter);
-    result = trim(texts[pluralTypeIndex(pluralRulesOrDefault, locale || 'en', options.smart_count)] || texts[0]);
+    result = (texts[pluralTypeIndex(pluralRulesOrDefault, locale || 'en', options.smart_count)] || texts[0]).trim();
   }
 
   // Interpolate: Creates a `RegExp` object for each interpolation placeholder.

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@
 
 var forEach = require('for-each');
 var warning = require('warning');
-var has = require('has');
+var has = function (obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+};
 
 var warn = function warn(message) {
   warning(false, message);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "for-each": "^0.3.3",
     "has": "^1.0.3",
-    "string.prototype.trim": "^1.1.2",
     "warning": "^4.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "author": "Spike Brehm <spike@airbnb.com>",
   "dependencies": {
     "for-each": "^0.3.3",
-    "has": "^1.0.3",
     "warning": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
[`string.prototype.trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Browser_compatibility) is implemented by all browsers up to IE9, so it's hard to justify its 12KB bundle size

`has` is much lighter, but trivial to replace