### PR TITLE
[Fix] French starts using plural at 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var defaultPluralRules = {
     bosnian_serbian: russianPluralGroups,
     chinese: function () { return 0; },
     croatian: russianPluralGroups,
-    french: function (n) { return n > 1 ? 1 : 0; },
+    french: function (n) { return n >= 2 ? 1 : 0; },
     german: function (n) { return n !== 1 ? 1 : 0; },
     russian: russianPluralGroups,
     lithuanian: function (n) {

--- a/index.js
+++ b/index.js
@@ -329,7 +329,6 @@ Polyglot.prototype.replace = function (newPhrases) {
   this.extend(newPhrases);
 };
 
-
 // ### polyglot.t(key, options)
 //
 // The most-used method. Provide a key, and `t` will return the
@@ -374,7 +373,6 @@ Polyglot.prototype.t = function (key, options) {
   }
   return result;
 };
-
 
 // ### polyglot.has(key)
 //

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "docco": "^0.7.0",
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.17.3",
+    "eslint": "^7.19.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.22.1",
     "mocha": "^3.5.3",
-    "safe-publish-latest": "^1.1.2",
+    "safe-publish-latest": "^1.1.4",
     "uglify-js": "^2.7.3"
   },
   "license": "BSD-2-Clause"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "for-each": "^0.3.3",
     "has": "^1.0.3",
-    "string.prototype.trim": "^1.1.2",
+    "string.prototype.trim": "^1.2.3",
     "warning": "^4.0.3"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -702,6 +702,8 @@ describe('transformPhrase', function () {
     // French rule: "0" is singular
     expect(Polyglot.transformPhrase(english, { smart_count: 0 }, 'fr')).to.equal('0 Name');
     expect(Polyglot.transformPhrase(english, { smart_count: 1 }, 'fr')).to.equal('1 Name');
+    expect(Polyglot.transformPhrase(english, { smart_count: 1.5 }, 'fr')).to.equal('1.5 Name');
+    // French rule: plural starts at 2 included
     expect(Polyglot.transformPhrase(english, { smart_count: 2 }, 'fr')).to.equal('2 Names');
     expect(Polyglot.transformPhrase(english, { smart_count: 3 }, 'fr')).to.equal('3 Names');
 


### PR DESCRIPTION
In French, plural mark starts from 2

Source: https://leconjugueur.lefigaro.fr/uk_pluriel_debut.php 