### PR TITLE
[Fix] Handle null and undefined gracefully in extend and unset

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ Polyglot.prototype.locale = function (newLocale) {
 //
 // This feature is used internally to support nested phrase objects.
 Polyglot.prototype.extend = function (morePhrases, prefix) {
-  forEach(entries(morePhrases), function (entry) {
+  forEach(entries(morePhrases || {}), function (entry) {
     var key = entry[0];
     var phrase = entry[1];
     var prefixedKey = prefix ? prefix + '.' + key : key;
@@ -337,7 +337,7 @@ Polyglot.prototype.unset = function (morePhrases, prefix) {
   if (typeof morePhrases === 'string') {
     delete this.phrases[morePhrases];
   } else {
-    forEach(entries(morePhrases), function (entry) {
+    forEach(entries(morePhrases || {}), function (entry) {
       var key = entry[0];
       var phrase = entry[1];
       var prefixedKey = prefix ? prefix + '.' + key : key;

--- a/test/index.js
+++ b/test/index.js
@@ -588,6 +588,14 @@ describe('extend', function () {
     polyglot = new Polyglot();
   });
 
+  it('handles null gracefully', function () {
+    expect(function () { polyglot.extend(null); }).to.not.throw();
+  });
+
+  it('handles undefined gracefully', function () {
+    expect(function () { polyglot.extend(undefined); }).to.not.throw();
+  });
+
   it('supports multiple extends, overriding old keys', function () {
     polyglot.extend({ aKey: 'First time' });
     polyglot.extend({ aKey: 'Second time' });
@@ -659,6 +667,14 @@ describe('unset', function () {
   var polyglot;
   beforeEach(function () {
     polyglot = new Polyglot();
+  });
+
+  it('handles null gracefully', function () {
+    expect(function () { polyglot.unset(null); }).to.not.throw();
+  });
+
+  it('handles undefined gracefully', function () {
+    expect(function () { polyglot.unset(undefined); }).to.not.throw();
   });
 
   it('unsets a key based on a string', function () {


### PR DESCRIPTION
In #127 we replaced for-each with alternative packages.
Unfortunately, for-each had also gracefully handled `null` and
`undefined` for us, but we didn't account for this when swapping in
the new packages. To avoid breaking people, I am adding a bit of
code to handle these scenarios.