### PR TITLE
Fix links to annotated source

### DIFF
--- a/docs/polyglot.html
+++ b/docs/polyglot.html
@@ -31,7 +31,7 @@
 
 polyglot.js may be freely distributed under the terms <span class="hljs-keyword">of</span> the BSD
 license. For all licensing information, details, and documention:
-http:<span class="hljs-comment">//airbnb.github.com/polyglot.js</span>
+<span class="hljs-attr">https</span>:<span class="hljs-comment">//airbnb.io/polyglot.js</span>
 </code></pre><p>Polyglot.js is an I18n helper library written in JavaScript, made to
 work both in the browser and in Node. It provides a simple solution for
 interpolation and pluralization, based off of Airbnb’s

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 //
 //     polyglot.js may be freely distributed under the terms of the BSD
 //     license. For all licensing information, details, and documentation:
-//     http://airbnb.github.com/polyglot.js
+//     https://airbnb.io/polyglot.js/
 //
 //
 // Polyglot.js is an I18n helper library written in JavaScript, made to


### PR DESCRIPTION
By #155, fixed links to annotated source.
But `index.js` comment still referenced the old URL.
This PR fixes links.
I tried to generating docs using `npm run docs` task, but the differences is too large, so I rewrote it manually.

Related: #166