### PR TITLE
Fix links to annotated source in GitHub pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ We’re also [hiring talented engineers](https://www.airbnb.com/jobs/departments
 
 View the [documentation on Github](https://github.com/airbnb/polyglot.js).
 
-View the [annotated source](http://airbnb.github.com/polyglot.js/polyglot.html).
+View the [annotated source](https://airbnb.io/polyglot.js/polyglot.html).
 
 Polylglot is agnostic to your translation backend. It doesn’t perform any translation; it simply gives you a way to manage translated phrases from your client- or server-side JavaScript application.
 

--- a/polyglot.html
+++ b/polyglot.html
@@ -31,7 +31,7 @@
 
 polyglot.js may be freely distributed under the terms <span class="hljs-keyword">of</span> the BSD
 license. For all licensing information, details, and documention:
-http:<span class="hljs-comment">//airbnb.github.com/polyglot.js</span></code></pre><p>Polyglot.js is an I18n helper library written in JavaScript, made to
+<span class="hljs-attr">https</span>:<span class="hljs-comment">//airbnb.io/polyglot.js</span></code></pre><p>Polyglot.js is an I18n helper library written in JavaScript, made to
 work both in the browser and in Node. It provides a simple solution for
 interpolation and pluralization, based off of Airbnb’s
 experience adding I18n functionality to its Backbone.js and Node apps.</p>


### PR DESCRIPTION
By https://github.com/airbnb/polyglot.js/pull/155, fixed links to annotated source.
But GitHub pages still referenced the old URL.
This PR fixes links.
I tried to generating docs using npm run docs task, but the differences is too large, so I rewrote it manually.

Fixed #159
Related: #163