### PR TITLE
[New] support custom replace implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "warning": "^4.0.3"
   },
   "devDependencies": {
+    "array.from": "^1.1.3",
     "aud": "^2.0.0",
     "chai": "^3.5.0",
     "docco": "^0.7.0",
@@ -43,6 +44,7 @@
     "mocha": "^3.5.3",
     "nyc": "^10.3.2",
     "safe-publish-latest": "^1.1.4",
+    "string.prototype.matchall": "^4.0.7",
     "uglify-js": "^2.7.3"
   },
   "license": "BSD-2-Clause"


### PR DESCRIPTION
in order to support interpolating types other then strings

as described in https://github.com/airbnb/polyglot.js/issues/170 this aims to allow use of complex types (like UI components) in interpolation slots.

```js
const p = new Polyglot({ phrases: { hello: 'Hello %{name}' } });
ReactDom.render(p.t(
  'hello',
  {
    name: <a href="https://example.org/">Example</a>
  }
))
```

Pre-Released this as [`@xiphe/node-polyglot@2.5.0-preview`](https://www.npmjs.com/package/@xiphe/node-polyglot).

Here is a working example with dynamic and nested components: https://codesandbox.io/s/admiring-framework-lb367l?file=/src/App.js
