### PR TITLE
Fix link to annotated source in Github pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ We’re also [hiring talented engineers](https://www.airbnb.com/jobs/departments
 
 View the [documentation on Github](https://github.com/airbnb/polyglot.js).
 
-View the [annotated source](http://airbnb.github.com/polyglot.js/polyglot.html).
+View the [annotated source](https://airbnb.io/polyglot.js/polyglot.html).
 
 Polylglot is agnostic to your translation backend. It doesn’t perform any translation; it simply gives you a way to manage translated phrases from your client- or server-side JavaScript application.
 

--- a/polyglot.html
+++ b/polyglot.html
@@ -31,7 +31,7 @@
 
 polyglot.js may be freely distributed under the terms <span class="hljs-keyword">of</span> the BSD
 license. For all licensing information, details, and documention:
-http:<span class="hljs-comment">//airbnb.github.com/polyglot.js</span></code></pre><p>Polyglot.js is an I18n helper library written in JavaScript, made to
+<span class="hljs-attr">https</span>:<span class="hljs-comment">//airbnb.io/polyglot.js</span></code></pre><p>Polyglot.js is an I18n helper library written in JavaScript, made to
 work both in the browser and in Node. It provides a simple solution for
 interpolation and pluralization, based off of Airbnb’s
 experience adding I18n functionality to its Backbone.js and Node apps.</p>


### PR DESCRIPTION
Fixing #159. [GitHub pages](https://github.com/airbnb/polyglot.js/blob/gh-pages/index.md#L15) is referencing wrong URL resulting 404, causing bad customer experience.