### PR TITLE
[New] Add pluralisation support for Romanian and Macedonian

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ var defaultPluralRules = {
     lithuanian: ['lt'],
     czech: ['cs', 'cs-CZ', 'sk'],
     polish: ['pl'],
-    icelandic: ['is'],
+    icelandic: ['is', 'mk'],
     slovenian: ['sl-SL'],
     romanian: ['ro']
   }

--- a/index.js
+++ b/index.js
@@ -88,6 +88,12 @@ var defaultPluralRules = {
         return 2;
       }
       return 3;
+    },
+    romanian: function (n) {
+      if (n === 1) { return 0; }
+      var lastTwo = n % 100;
+      if (n === 0 || (lastTwo >= 2 && lastTwo <= 19)) { return 1; }
+      return 2;
     }
   },
 
@@ -106,7 +112,8 @@ var defaultPluralRules = {
     czech: ['cs', 'cs-CZ', 'sk'],
     polish: ['pl'],
     icelandic: ['is'],
-    slovenian: ['sl-SL']
+    slovenian: ['sl-SL'],
+    romanian: ['ro']
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -588,6 +588,27 @@ describe('locale-specific pluralization rules', function () {
     expect(polyglot.t('n_days', 119)).to.equal('119 zile');
     expect(polyglot.t('n_days', 120)).to.equal('120 de zile');
   });
+
+  it('pluralizes in Macedonian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} ден',
+      '%{smart_count} дена'
+    ];
+    var phrases = {
+      n_days: whatSomeoneTranslated.join(' |||| ')
+    };
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'mk' });
+
+    expect(polyglot.t('n_days', 0)).to.equal('0 дена');
+    expect(polyglot.t('n_days', 1)).to.equal('1 ден');
+    expect(polyglot.t('n_days', 2)).to.equal('2 дена');
+    expect(polyglot.t('n_days', 10)).to.equal('10 дена');
+    expect(polyglot.t('n_days', 11)).to.equal('11 дена');
+    expect(polyglot.t('n_days', 21)).to.equal('21 ден');
+    expect(polyglot.t('n_days', 100)).to.equal('100 дена');
+    expect(polyglot.t('n_days', 101)).to.equal('101 ден');
+    expect(polyglot.t('n_days', 111)).to.equal('111 дена');
+  });
 });
 
 describe('custom pluralRules', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -563,6 +563,31 @@ describe('locale-specific pluralization rules', function () {
     expect(polyglot.t('n_votes', 92)).to.equal('92 balsai');
     expect(polyglot.t('n_votes', 102)).to.equal('102 balsai');
   });
+
+  it('pluralizes in Romanian', function () {
+    var whatSomeoneTranslated = [
+      '%{smart_count} zi',
+      '%{smart_count} zile',
+      '%{smart_count} de zile'
+    ];
+    var phrases = {
+      n_days: whatSomeoneTranslated.join(' |||| ')
+    };
+    var polyglot = new Polyglot({ phrases: phrases, locale: 'ro' });
+
+    expect(polyglot.t('n_days', 0)).to.equal('0 zile');
+    expect(polyglot.t('n_days', 1)).to.equal('1 zi');
+    expect(polyglot.t('n_days', 2)).to.equal('2 zile');
+    expect(polyglot.t('n_days', 10)).to.equal('10 zile');
+    expect(polyglot.t('n_days', 19)).to.equal('19 zile');
+    expect(polyglot.t('n_days', 20)).to.equal('20 de zile');
+    expect(polyglot.t('n_days', 21)).to.equal('21 de zile');
+    expect(polyglot.t('n_days', 100)).to.equal('100 de zile');
+    expect(polyglot.t('n_days', 101)).to.equal('101 de zile');
+    expect(polyglot.t('n_days', 102)).to.equal('102 zile');
+    expect(polyglot.t('n_days', 119)).to.equal('119 zile');
+    expect(polyglot.t('n_days', 120)).to.equal('120 de zile');
+  });
 });
 
 describe('custom pluralRules', function () {


### PR DESCRIPTION
This PR adds support for Romanian (`ro` locale) and Macedonian (`mk` locale)

Romanian pluralisation rules
https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#ro

Macedonian pluralisation rules (same cardinal-integer rule as Icelandic)
https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#mk