### PR TITLE
Chinese starts using plural at 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var defaultPluralRules = {
       return lastTwo >= 11 ? 4 : 5;
     },
     bosnian_serbian: russianPluralGroups,
-    chinese: function () { return 0; },
+    chinese: function (n) { return n >= 2 ? 1 : 0; },
     croatian: russianPluralGroups,
     french: function (n) { return n >= 2 ? 1 : 0; },
     german: function (n) { return n !== 1 ? 1 : 0; },

--- a/test/index.js
+++ b/test/index.js
@@ -827,6 +827,7 @@ describe('unset', function () {
 describe('transformPhrase', function () {
   var simple = '%{name} is %{attribute}';
   var english = '%{smart_count} Name |||| %{smart_count} Names';
+  var chinese = '%{smart_count} 个 |||| %{smart_count} 个(plural)';
   var arabic = [
     'ولا صوت',
     'صوت واحد',
@@ -906,5 +907,12 @@ describe('transformPhrase', function () {
     expect(Polyglot.transformPhrase(english, { smart_count: 0 }, 'fr')).to.equal('0 Name');
     expect(Polyglot.transformPhrase(english, { smart_count: 2 }, 'fr')).to.equal('2 Names');
     expect(Polyglot.transformPhrase(english, { smart_count: 2 }, 'fr')).to.equal('2 Names');
+  });
+
+  it('selects the correct plural form based on smart_count', function () {
+    expect(Polyglot.transformPhrase(chinese, { smart_count: 0 }, 'zh')).to.equal('0 个');
+    expect(Polyglot.transformPhrase(chinese, { smart_count: 1 }, 'zh')).to.equal('1 个');
+    expect(Polyglot.transformPhrase(chinese, { smart_count: 2 }, 'zh')).to.equal('2 个(plural)');
+    expect(Polyglot.transformPhrase(chinese, { smart_count: 3 }, 'zh')).to.equal('3 个(plural)');
   });
 });


### PR DESCRIPTION
Chinese has pluralization though the noun may not change to nouns like `1个人` and `2个人` that one person and two persons in English. I get the problem in [this](https://github.com/navidrome/navidrome/issues/2261) which uses `smart_count` to sum because the code `return 0` in all values.