### PR TITLE
Fix Chinese pluralization bug in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var defaultPluralRules = {
       return lastTwo >= 11 ? 4 : 5;
     },
     bosnian_serbian: russianPluralGroups,
-    chinese: function () { return 0; },
+    chinese: function (n) { return n === 1 ? 0 : 1; },
     croatian: russianPluralGroups,
     french: function (n) { return n >= 2 ? 1 : 0; },
     german: function (n) { return n !== 1 ? 1 : 0; },


### PR DESCRIPTION
Modify the chinese function to return 0 for singular and 1 for plural.