### PR TITLE
[FIX] Travis CI image URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ You should pass in a third argument, the locale, to specify the correct plural t
 
 ## [History](CHANGELOG.md)
 
-[travis-image]: https://travis-ci.org/airbnb/polyglot.js.svg
+[travis-image]: https://travis-ci.org/airbnb/polyglotjs.svg
 [travis-url]: https://travis-ci.org/airbnb/polyglot.js
 
 ## Related projects


### PR DESCRIPTION
Old:
<img width="224" height="169" alt="Screenshot 2026-06-04 at 09 44 34" src="https://github.com/user-attachments/assets/65820bed-4da4-493a-b854-0832f88c9cfb" />


New:
<img width="244" height="160" alt="Screenshot 2026-06-04 at 09 43 59" src="https://github.com/user-attachments/assets/ee58239f-1453-4a7d-b2c4-ff0764d3449e" />